### PR TITLE
Fix to work without the language key of the default language within the URL.

### DIFF
--- a/Classes/Hooks/FrontendHook.php
+++ b/Classes/Hooks/FrontendHook.php
@@ -114,8 +114,6 @@ class FrontendHook {
 
 						if (is_array($typo3_conf_var_realurl['preVars'][$key]['valueMap']) && array_key_exists($lang,$typo3_conf_var_realurl['preVars'][$key]['valueMap'])) {
 							$url_array[] = $lang;
-						} elseif ($typo3_conf_var_realurl['preVars'][$key]['valueDefault']) {
-							$url_array[] = $typo3_conf_var_realurl['preVars'][$key]['valueDefault'];
 						}
 					}
 				}


### PR DESCRIPTION
Without this fix the language key has to be a part of the URL in any case.

1. Setup:
---------
        ...
// Language configuration
        array(
            "GETvar" => "L",
            "valueMap" => array(
                // id"s need to line up with Website Language Ids in TYPO3
//                "de" => "0", // Do not configure the default language here. It generates the default language to be in the URL like /de/... . That means doublicate Content as well.
                "en" => "1",
            ),
            "valueDefault" => "de",
            "noMatch" => "bypass",
        ),
...

2. Setup:
---------
        ...
// Language configuration
        array(
            "GETvar" => "L",
            "valueMap" => array(
                "de" => "0",
                "en" => "1",
            ),
            "valueDefault" => "de",
            "noMatch" => "bypass",
        ),
...

The fix should work for both setups.