### PR TITLE
Safer logic for deciding http/https

### DIFF
--- a/Classes/Hooks/FrontendHook.php
+++ b/Classes/Hooks/FrontendHook.php
@@ -197,7 +197,7 @@ class FrontendHook
 
         $useHttps = $_SERVER['HTTPS'];
 
-        return (empty($useHttps) ? "http" : "https") . "://".implode("/",$url_array);
+        return ((!empty($useHttps) && $useHttps !== 'off') ? "https" : "http") . "://".implode("/",$url_array);
     }
 
 


### PR DESCRIPTION
Some servers return "off" for `$_SERVER['HTTPS']` when http is used. This fixes that. Must be not empty and not "off" to use https.