### PR TITLE
Prevent redirect or request loop for bad config

### DIFF
--- a/Classes/Hooks/FrontendHook.php
+++ b/Classes/Hooks/FrontendHook.php
@@ -83,10 +83,16 @@ class FrontendHook
 
     /**
      * @param $params
+     * @throws \Exception
      * @param \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController $obj
      */
     public function pageErrorHandler(&$params, \TYPO3\CMS\Frontend\Controller\TypoScriptFrontendController &$obj)
     {
+        if (GeneralUtility::_GP('tx_realurl404multilingual') == '1')
+        {
+            // we are in a infinite redirect/request loop, which we need to stop
+            throw new \Exception('404 page handler stuck in a redirect/request loop. Please check your configration',1474969985);
+        }
 
         $extConf = unserialize($GLOBALS['TYPO3_CONF_VARS']['EXT']['extConf']['realurl_404_multilingual']);
         $currentUrl = $params['currentUrl'];
@@ -99,7 +105,7 @@ class FrontendHook
             $unauthorizedPage = $this->config['unauthorizedPage'];
             $unauthorizedPage = (!$unauthorizedPage ? '401' : $unauthorizedPage);
             $destinationUrl = $this->getDestinationUrl($currentUrl, $unauthorizedPage);
-            $destinationUrl .= "?return_url=".urlencode($currentUrl);
+            $destinationUrl .= "?return_url=".urlencode($currentUrl)."&tx_realurl404multilingual=1";
             //$header = "HTTP/1.0 401 Unauthorized";
             $mode = self::MODE_REDIRECT; // force redirect
         } else {


### PR DESCRIPTION
This fixes problem with possible 404 loop requests, if for example someone renames 404 page, so the page under /404/ doesn't exist for current domain. I was thinking if, it should return a default 404 page, but decided to use exception, so system administrator can see it in their logs and fix it instead of users getting server 404 page. 