### PR TITLE
[FEATURE] Add optional redirects follow for curl

### DIFF
--- a/Classes/Hooks/FrontendHook.php
+++ b/Classes/Hooks/FrontendHook.php
@@ -305,7 +305,10 @@ class FrontendHook
             curl_setopt($ch, CURLOPT_POSTFIELDS,
                 'tx_realurl404multilingual=1' . $this->addFESeesionKeyStringIfLoggedIn());
 
-            //curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+            if($GLOBALS['TYPO3_CONF_VARS']['HTTP']['follow_redirects']) {
+                curl_setopt($ch, CURLOPT_FOLLOWLOCATION, true);
+                curl_setopt($ch, CURLOPT_MAXREDIRS, (int)$GLOBALS['TYPO3_CONF_VARS']['HTTP']['max_redirects']);
+            }
             curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
             curl_setopt($ch, CURLOPT_TIMEOUT, 5);
             curl_setopt($ch, CURLOPT_USERAGENT, GeneralUtility::getIndpEnv('HTTP_USER_AGENT'));


### PR DESCRIPTION
In some cases curl can't fetch the page directly, because of some server-side redirects, like http to https or domain.tld/404 to domain.tld/404/.
This request utilizes settings from TYPO3 core to follow redirects, if configured.